### PR TITLE
Use shared transaction model types in transaction feature modules

### DIFF
--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { useAppSelector } from '@/hooks/useAppSelector';
-import { Transaction } from '../transactions/transactionSlice';
+import { Transaction } from '@/types/transaction';
 import Card from '@/components/Card'
 import IncomeForm from '../income/IncomeForm'
 import ExpenseForm from '../income/ExpenseForm';

--- a/src/features/transactions/transactionSlice.tsx
+++ b/src/features/transactions/transactionSlice.tsx
@@ -1,15 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-export type EntryType = "income" | "expense";
-
-export interface Transaction {
-    id: string;
-    type: EntryType;
-    category: string;
-    amount: number;
-    note?: string;
-    date: string;
-}
+import { Transaction } from "@/types/transaction";
 
 interface TransactionState {
     transactions: Transaction[];


### PR DESCRIPTION
### Motivation
- Consolidate the `EntryType`/`Transaction` model into a single canonical location to avoid duplicated type declarations and keep typing consistent across features.

### Description
- Removed local `EntryType`/`Transaction` declarations from `src/features/transactions/transactionSlice.tsx` and imported `Transaction` from `@/types/transaction` instead.
- Updated `src/features/dashboard/Dashboard.tsx` to import `Transaction` from `@/types/transaction` so components reference the shared model.

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968b612d9c83258a60ee9d0b5d49e8)