### PR TITLE
Redesign FinTrack dashboard with modern professional UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,14 @@
-import Navbar from "@/components/Navbar";
-import Dashboard from "@/features/dashboard/Dashboard";
+import Navbar from '@/components/Navbar';
+import Dashboard from '@/features/dashboard/Dashboard';
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-800 to-gray-900 text-gray-900 dark:text-white">
-      <Navbar/>
-      <main className="p-4">
-        <Dashboard/>
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_40%),radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.14),_transparent_45%)]" />
+      <Navbar />
+      <main className="relative px-4 sm:px-6 lg:px-8">
+        <Dashboard />
       </main>
-      </div>
+    </div>
   );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,17 +1,30 @@
-import React from 'react'
+import React from 'react';
 
 interface CardProps {
-    title?: string;
-    children: React.ReactNode;
+  title?: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
 }
 
-const Card: React.FC<CardProps> = ({title,children}) => {
+const Card: React.FC<CardProps> = ({ title, subtitle, action, children, className = '' }) => {
   return (
-    <div className="bg-white dark:bg-gradient-to-bl from-gray-500 to-gray-700 rounded-2xl shadow-md p-4">
-        {title && <h2 className="text-lg font-semibold mb-2"> {title} </h2>}
-        {children}
-    </div>
-  )
+    <section
+      className={`rounded-2xl border border-white/10 bg-slate-900/70 p-5 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.9)] backdrop-blur ${className}`}
+    >
+      {(title || subtitle || action) && (
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            {title && <h2 className="text-base font-semibold text-slate-100">{title}</h2>}
+            {subtitle && <p className="mt-1 text-sm text-slate-400">{subtitle}</p>}
+          </div>
+          {action}
+        </header>
+      )}
+      {children}
+    </section>
+  );
 };
 
-export default Card
+export default Card;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,19 @@
-import React from 'react'
+import React from 'react';
 
 function Navbar() {
   return (
-    <header className="p-4 shadow bg-white dark:bg-gray-800">
-        <h1 className="text-2xl font-bold text-center w-full">FinTrack</h1>
+    <header className="sticky top-0 z-10 border-b border-white/10 bg-slate-950/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-cyan-300">Personal Finance</p>
+          <h1 className="text-2xl font-bold text-white">FinTrack Dashboard</h1>
+        </div>
+        <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 text-xs font-medium text-emerald-300">
+          Live
+        </span>
+      </div>
     </header>
-  )
+  );
 }
 
-export default Navbar
+export default Navbar;

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -1,77 +1,103 @@
 'use client';
 
-import React from 'react'
-import { useAppSelector } from '@/hooks/useAppSelector';
-import { Transaction } from '../transactions/transactionSlice';
-import Card from '@/components/Card'
-import IncomeForm from '../income/IncomeForm'
+import React from 'react';
+import Card from '@/components/Card';
 import ExpenseForm from '../income/ExpenseForm';
+import IncomeForm from '../income/IncomeForm';
+import TransactionList from '../transactions/TransactionList';
+import { useAppSelector } from '@/hooks/useAppSelector';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
 
 const Dashboard = () => {
-    const transactions = useAppSelector(state => state.transactions.transactions);
-    console.log('Redux Transactions:', transactions);
+  const transactions = useAppSelector((state) => state.transactions.transactions);
 
-    const income  = transactions.filter(tx => tx.type === 'income');
-    const expense = transactions.filter(tx => tx.type === 'expense');
+  const income = transactions.filter((tx) => tx.type === 'income');
+  const expense = transactions.filter((tx) => tx.type === 'expense');
 
-    //totals
-    const totalIncome = income.reduce((acc,tx) => acc + tx.amount,0);
-    const totalExpenses = expense.reduce((acc,tx) => acc + tx.amount,0);
-    const net = totalIncome - totalExpenses;
+  const totalIncome = income.reduce((acc, tx) => acc + tx.amount, 0);
+  const totalExpenses = expense.reduce((acc, tx) => acc + tx.amount, 0);
+  const net = totalIncome - totalExpenses;
 
-    const formatCurrency = (amount: number) => 
-        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD'}).format(amount);
+  const expenseByCategory = expense.reduce<Record<string, number>>((acc, tx) => {
+    acc[tx.category] = (acc[tx.category] ?? 0) + tx.amount;
+    return acc;
+  }, {});
+
+  const topExpenseCategories = Object.entries(expenseByCategory)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 4);
+
+  const summaryCards = [
+    {
+      title: 'Total Income',
+      amount: totalIncome,
+      accent: 'from-emerald-500/20 to-emerald-400/5 border-emerald-400/30',
+    },
+    {
+      title: 'Total Expenses',
+      amount: totalExpenses,
+      accent: 'from-rose-500/20 to-rose-400/5 border-rose-400/30',
+    },
+    {
+      title: 'Net Balance',
+      amount: net,
+      accent: net >= 0 ? 'from-cyan-500/20 to-cyan-400/5 border-cyan-400/30' : 'from-orange-500/20 to-orange-400/5 border-orange-400/30',
+    },
+  ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-        <Card title="Summary">
-            <p>Total Income: {formatCurrency(totalIncome)}</p>
-            <p>Total Expenses: {formatCurrency(totalExpenses)}</p>
-            <p>Net: {formatCurrency(net)}</p>
-        </Card>
+    <div className="mx-auto grid w-full max-w-7xl gap-6 py-6">
+      <section className="grid gap-4 md:grid-cols-3">
+        {summaryCards.map((card) => (
+          <Card key={card.title} className={`bg-gradient-to-br ${card.accent}`}>
+            <p className="text-sm text-slate-300">{card.title}</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{currencyFormatter.format(card.amount)}</p>
+          </Card>
+        ))}
+      </section>
 
-        <Card title="Recent Income">
-            {income.length === 0 ? (
-                <p>No Income Entires yet</p>
-            ):(
-                <ul className="space-y-2">
-                    {income.slice(-3).reverse().map((tx: Transaction) =>(
-                        <li key= {tx.id} className="flex justify-between text-green-700">
-                            <span>{tx.category}</span>
-                            <span>{formatCurrency(tx.amount)}</span>
-                        </li>
-                    ))}
-                </ul>
+      <section className="grid gap-6 xl:grid-cols-3">
+        <div className="space-y-6 xl:col-span-2">
+          <TransactionList />
+        </div>
+
+        <div className="space-y-6">
+          <Card title="Spending Breakdown" subtitle="Top categories this period">
+            {topExpenseCategories.length === 0 ? (
+              <p className="text-sm text-slate-400">Add expenses to populate your category insights.</p>
+            ) : (
+              <ul className="space-y-3">
+                {topExpenseCategories.map(([category, amount]) => (
+                  <li key={category} className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-800/60 px-3 py-2">
+                    <span className="text-sm text-slate-200">{category}</span>
+                    <span className="text-sm font-semibold text-rose-300">{currencyFormatter.format(amount)}</span>
+                  </li>
+                ))}
+              </ul>
             )}
-        </Card>
+          </Card>
 
-        <Card title="Recent Expenses">
-            {income.length === 0 ? (
-                <p>No Income Entires yet</p>
-            ):(
-                <ul className="space-y-2">
-                    {expense.slice(-3).reverse().map((tx: Transaction) =>(
-                        <li key= {tx.id} className="flex justify-between text-red-700">
-                            <span>{tx.category}</span>
-                            <span>{formatCurrency(tx.amount)}</span>
-                        </li>
-                    ))}
-                </ul>
-            )}
-        </Card>
+          <Card title="Cashflow Notes" subtitle="Quick guidance">
+            <ul className="space-y-2 text-sm text-slate-300">
+              <li>• Keep expenses below 70% of income for healthy monthly margin.</li>
+              <li>• Review the top spending category each week and trim recurring costs.</li>
+              <li>• Add notes to transactions to improve future budgeting decisions.</li>
+            </ul>
+          </Card>
+        </div>
+      </section>
 
-        <Card title="Savings Goals">
-            <p>No goals created yet.</p>
-        </Card>
-
-        <Card title="Spending Overview">
-            <p>Chart goes here.</p>
-        </Card>
-
-        <IncomeForm/>
-        <ExpenseForm/>
+      <section className="grid gap-6 md:grid-cols-2">
+        <IncomeForm />
+        <ExpenseForm />
+      </section>
     </div>
-  )
-}
+  );
+};
 
-export default Dashboard
+export default Dashboard;

--- a/src/features/income/ExpenseForm.tsx
+++ b/src/features/income/ExpenseForm.tsx
@@ -1,70 +1,78 @@
-import React, { useState } from 'react'
+'use client';
+
+import React, { useState } from 'react';
+import { v4 as uuid } from 'uuid';
 import Card from '@/components/Card';
-import {v4 as uuid} from 'uuid';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
 import { addTransaction } from '@/features/transactions/transactionSlice';
 
 const ExpenseForm: React.FC = () => {
-    const dispatch = useAppDispatch();
-    const [amount, setAmount] = useState('');
-    const [category, setCategory] =useState('');
-    const [note, setNote] = useState('');
+  const dispatch = useAppDispatch();
+  const [amount, setAmount] = useState('');
+  const [category, setCategory] = useState('');
+  const [note, setNote] = useState('');
 
-    const handleSubmit = (e: React.FormEvent) =>{
-        e.preventDefault();
-        if (!amount || !category) return;
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!amount || !category) return;
 
-        dispatch(
-            addTransaction({
-                id: uuid(),
-                type: 'expense',
-                amount: parseFloat(amount),
-                category,
-                note,
-                date: new Date().toISOString(),
-            })
-        );
-        setAmount('');
-        setCategory('');
-        setNote('');
-    };
+    dispatch(
+      addTransaction({
+        id: uuid(),
+        type: 'expense',
+        amount: parseFloat(amount),
+        category,
+        note,
+        date: new Date().toISOString(),
+      }),
+    );
 
-    
+    setAmount('');
+    setCategory('');
+    setNote('');
+  };
+
   return (
-    <Card title="Add Expense">
-        <form onSubmit={handleSubmit} className="space-y-4">
-            <input
-            type="number"
-            placeholder="Amount"
-            value={amount}
-            onChange={e => setAmount(e.target.value)}
-            className="w-full p-2 border rounded bg-white text-gray-900"
-            required
-            />
-            <select
-            title='category_selector' 
-            value={category}
-            onChange={e => setCategory(e.target.value)}
-            className="w-full p-2 border rounded bg-white text-gray-900"
-            required
-            >
-                <option value="">Select Category</option>
-                <option value="Rent">Rent</option>
-                <option value="Groceries">Groceries</option>
-                <option value="Entertainment">Entertainment</option>
-                <option value="Other">Other</option>
-            </select>
-            <input 
-            type ="text"
-            placeholder="note (optional)"
-            value = {note}
-            onChange={e => setNote(e.target.value)}
-            className= "w-full p-2 border rounded bg-white text-gray-900"
-            />
-            <button type= "submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Add Expense</button>
-        </form>
+    <Card title="Add Expense" subtitle="Capture daily and recurring spend">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="number"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none"
+          required
+        />
+        <select
+          title="expense_category_selector"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 focus:border-cyan-400 focus:outline-none"
+          required
+        >
+          <option value="">Select Category</option>
+          <option value="Rent">Rent</option>
+          <option value="Groceries">Groceries</option>
+          <option value="Entertainment">Entertainment</option>
+          <option value="Utilities">Utilities</option>
+          <option value="Other">Other</option>
+        </select>
+        <input
+          type="text"
+          placeholder="Note (optional)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none"
+        />
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-rose-500 px-4 py-2 font-medium text-white transition hover:bg-rose-400"
+        >
+          Add Expense
+        </button>
+      </form>
     </Card>
   );
 };
 
-export default ExpenseForm
+export default ExpenseForm;

--- a/src/features/income/IncomeForm.tsx
+++ b/src/features/income/IncomeForm.tsx
@@ -1,72 +1,77 @@
 'use client';
-import React, { useState } from 'react'
+
+import React, { useState } from 'react';
+import { v4 as uuid } from 'uuid';
 import Card from '@/components/Card';
-import {v4 as uuid} from 'uuid';
 import { useAppDispatch } from '@/hooks/useAppDispatch';
 import { addTransaction } from '@/features/transactions/transactionSlice';
 
 const IncomeForm: React.FC = () => {
-    const dispatch = useAppDispatch();
-    const [amount, setAmount] = useState('');
-    const [category, setCategory] = useState('');
-    const [note, setNote] = useState('');
+  const dispatch = useAppDispatch();
+  const [amount, setAmount] = useState('');
+  const [category, setCategory] = useState('');
+  const [note, setNote] = useState('');
 
-    const handleSubmit = (e: React.FormEvent) =>{
-        e.preventDefault();
-        if (!amount || !category) return;
-        console.log('Submitting income: ', {amount, category, note});
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!amount || !category) return;
 
-        dispatch(
-            addTransaction({
-                id: uuid(),
-                type: 'income',
-                amount: parseFloat(amount),
-                category,
-                note,
-                date: new Date().toISOString(),
-            })
-        );
-        setAmount('');
-        setCategory('');
-        setNote('');
-    };
+    dispatch(
+      addTransaction({
+        id: uuid(),
+        type: 'income',
+        amount: parseFloat(amount),
+        category,
+        note,
+        date: new Date().toISOString(),
+      }),
+    );
 
-    
+    setAmount('');
+    setCategory('');
+    setNote('');
+  };
+
   return (
-    <Card title="Add Income">
-        <form onSubmit={handleSubmit} className="space-y-4">
-            <input
-            type="number"
-            placeholder="Amount"
-            value={amount}
-            onChange={e => setAmount(e.target.value)}
-            className="w-full p-2 border rounded bg-white text-gray-900"
-            required
-            />
-            <select
-                title='category_selector' 
-                value={category}
-                onChange={e => setCategory(e.target.value)}
-                className="w-full p-2 border rounded bg-white text-gray-900"
-                required
-            >
-                <option value="">Select Category</option>
-                <option value="Salary">Salary</option>
-                <option value="Freelance">Freelance</option>
-                <option value="Investments">Investments</option>
-                <option value="Other">Other</option>
-            </select>
-            <input 
-            type ="text"
-            placeholder="note (optional)"
-            value = {note}
-            onChange={e => setNote(e.target.value)}
-            className= "w-full p-2 border rounded bg-white text-gray-900"
-            />
-            <button name = "income" type= "submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Add Income</button>
-        </form>
+    <Card title="Add Income" subtitle="Track salary, freelance, and more">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="number"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none"
+          required
+        />
+        <select
+          title="income_category_selector"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 focus:border-cyan-400 focus:outline-none"
+          required
+        >
+          <option value="">Select Category</option>
+          <option value="Salary">Salary</option>
+          <option value="Freelance">Freelance</option>
+          <option value="Investments">Investments</option>
+          <option value="Other">Other</option>
+        </select>
+        <input
+          type="text"
+          placeholder="Note (optional)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          className="w-full rounded-lg border border-white/10 bg-slate-800 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none"
+        />
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-emerald-500 px-4 py-2 font-medium text-slate-950 transition hover:bg-emerald-400"
+        >
+          Add Income
+        </button>
+      </form>
     </Card>
   );
 };
 
-export default IncomeForm
+export default IncomeForm;

--- a/src/features/transactions/TransactionList.tsx
+++ b/src/features/transactions/TransactionList.tsx
@@ -1,18 +1,42 @@
-import { useAppSelector } from '@/hooks/useAppSelector';
 import Card from '@/components/Card';
+import { useAppSelector } from '@/hooks/useAppSelector';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
 
 const TransactionList = () => {
-  const transactions = useAppSelector(state => state.transactions.transactions);
+  const transactions = useAppSelector((state) => state.transactions.transactions);
 
   return (
-    <Card title="All Transactions">
-      <ul className="divide-y divide-gray-300 dark:divide-gray-700">
-        {transactions.map(t => (
-          <li key={t.id} className="py-2">
-            <strong>{t.type.toUpperCase()}</strong> • ${t.amount} • {t.category}
-          </li>
-        ))}
-      </ul>
+    <Card title="All Transactions" subtitle="Latest activity across income and expenses">
+      {transactions.length === 0 ? (
+        <p className="text-sm text-slate-400">No transactions yet. Add income or expenses to get started.</p>
+      ) : (
+        <ul className="space-y-2">
+          {[...transactions].reverse().slice(0, 8).map((transaction) => (
+            <li
+              key={transaction.id}
+              className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-800/60 px-3 py-2"
+            >
+              <div>
+                <p className="text-sm font-medium text-slate-100">{transaction.category}</p>
+                <p className="text-xs text-slate-400">{new Date(transaction.date).toLocaleDateString()}</p>
+              </div>
+              <span
+                className={`text-sm font-semibold ${
+                  transaction.type === 'income' ? 'text-emerald-300' : 'text-rose-300'
+                }`}
+              >
+                {transaction.type === 'income' ? '+' : '-'}
+                {currencyFormatter.format(transaction.amount)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
### Motivation
- Refresh the app UI to a modern, streamlined dashboard aesthetic with improved hierarchy and spacing for a professional finance console.
- Unify component visuals and form interactions so income/expense workflows and transaction summaries feel consistent and clearer.
- Improve immediate insights (KPIs, recent activity, category breakdown) so users can quickly understand cashflow at a glance.

### Description
- Reworked the app shell and entry page visuals in `src/app/page.tsx` to use a dark premium background with subtle radial accents and updated layout padding. 
- Rebuilt core primitives with `src/components/Card.tsx` (new `title`/`subtitle`/`action` props, blur/shadow styling) and `src/components/Navbar.tsx` (sticky glass-style header and status chip). 
- Overhauled the dashboard in `src/features/dashboard/Dashboard.tsx` to present KPI summary cards, a recency-first transaction panel, spending breakdown, guidance notes, and side-by-side Income/Expense forms. 
- Refreshed forms in `src/features/income/IncomeForm.tsx` and `src/features/income/ExpenseForm.tsx` with consistent styling, improved inputs/selects/buttons, and added the `use client` directive to `ExpenseForm` to keep hook usage valid in the App Router. 
- Upgraded `src/features/transactions/TransactionList.tsx` with currency formatting, semantic color coding for income vs expense, recency ordering, empty-state messaging, and improved item layout.

### Testing
- Ran `npm ci` which completed with warnings but left `node_modules` present (environment produced some EventEmitter warnings). 
- Ran `npm run lint` which failed in this environment because the `next` executable is not available (`sh: 1: next: not found`). 
- Attempted to start the dev server with `npm run dev` for visual verification, but it also failed due to the missing `next` binary so automated visual/screenshot validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967dc9dc208325934518672d83ef5a)